### PR TITLE
Centralized Management of User Settings  [Closes #6, #7, #8]

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,3 +216,5 @@ This project is licensed under the [MIT License](🎯).
 </details>
 
 <br>
+ 
+test

--- a/README.md
+++ b/README.md
@@ -217,4 +217,3 @@ This project is licensed under the [MIT License](🎯).
 
 <br>
  
-test

--- a/app/(dashboard)/_components/UserDropdown.tsx
+++ b/app/(dashboard)/_components/UserDropdown.tsx
@@ -23,9 +23,11 @@ import {
   SettingsIcon,
   Trophy,
 } from "lucide-react";
+import { useCustomToast } from "@/lib/useCustomToast";
 
 export const UserDropdown = () => {
   const { modal, dispatch } = useModalContext();
+  const customToast = useCustomToast();
 
   // 🎯 to-do-list : get user data
   //const { destruct, user, data } = useUserDataDevon();
@@ -36,6 +38,7 @@ export const UserDropdown = () => {
   //👇🎯 testing toast notifications
   const ztmTest = () => {
     toast.success("This is a Test notification 🎯🧪");
+    customToast("Hello?")
   };
 
   return (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { SettingsReducerProvider } from "@/components/providers/SettingsReducerProvider";
 import { AuthContextProvider } from "@/components/providers/AuthProvider";
 import { ThemeProvider } from "@/components/providers/ThemeProvider";
 import ToasterProvider from "@/components/providers/ToasterProvider";
@@ -12,6 +13,7 @@ import "./globals.css";
 
 const inter = Inter({ subsets: ["latin"] });
 
+//🎯 to-do-list
 // 🤔 so I cant use meta data here and use client - use client is required in order to use authContext ... need to find a better space for metadata
 // export const metadata: Metadata = {
 //   title: "ZTMReady",
@@ -43,7 +45,7 @@ export default function RootLayout({
             disableTransitionOnChange
             storageKey="ztmready-theme"
           >
-            {children}
+            <SettingsReducerProvider>{children}</SettingsReducerProvider>
           </ThemeProvider>
         </AuthContextProvider>
       </body>

--- a/components/modals/settings-modal.tsx
+++ b/components/modals/settings-modal.tsx
@@ -1,7 +1,11 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { ModeToggle } from "../ThemeToggle";
 import { useModalContext } from "../providers/ModalReducerProvider";
+import {
+  SettingsReducerContext,
+  ToggleAction,
+} from "../providers/SettingsReducerProvider";
 
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
@@ -17,6 +21,10 @@ import {
 export const SettingsModal = () => {
   const [isMounted, setIsMounted] = useState(false);
   const { modal, dispatch } = useModalContext();
+
+  const { state: toggleState, dispatch: toggleDispatch } = useContext(
+    SettingsReducerContext
+  );
 
   // ✅ listening if should be mounted
   useEffect(() => {
@@ -55,14 +63,17 @@ export const SettingsModal = () => {
           <SettingTitle>
             <Label>General Notifications 🎯</Label>
             <SettingDescription>
-              Do you want to turn on general notifcations?
+              Enable this to receive general notifications as toast alerts.
             </SettingDescription>
           </SettingTitle>
           <Switch
-          //checked={}
-          //onCheckedChange={}
-          //disabled
-          //aria-readonly
+            checked={toggleState.generalNotifications} // Use the toggle state
+            onCheckedChange={
+              () =>
+                toggleDispatch({
+                  type: "TOGGLE_GENERAL_NOTIFICATIONS",
+                } as ToggleAction) // Dispatch action to toggle the state
+            }
           />
         </SettingSection>
 
@@ -70,14 +81,17 @@ export const SettingsModal = () => {
           <SettingTitle>
             <Label>Hide correct answer 🎯</Label>
             <SettingDescription>
-              Disable the ability to check the correct answer until complete.
+              Disable the ability to see correct answers.
             </SettingDescription>
           </SettingTitle>
           <Switch
-          //checked={}
-          //onCheckedChange={}
-          //disabled
-          //aria-readonly
+            checked={toggleState.hideCorrectAnswer} // Use the toggle state
+            onCheckedChange={
+              () =>
+                toggleDispatch({
+                  type: "TOGGLE_HIDE_CORRECT_ANSWER",
+                } as ToggleAction) // Dispatch action to toggle the state
+            }
           />
         </SettingSection>
 
@@ -85,14 +99,17 @@ export const SettingsModal = () => {
           <SettingTitle>
             <Label>Log events 🎯</Label>
             <SettingDescription>
-              Do you want to see all log notifications
+              Enable this to see all event logs as toast notifications.
             </SettingDescription>
           </SettingTitle>
           <Switch
-          //checked={}
-          //onCheckedChange={}
-          //disabled
-          //aria-readonly
+            checked={toggleState.logEvents} // Use the toggle state
+            onCheckedChange={
+              () =>
+                toggleDispatch({
+                  type: "TOGGLE_LOG_EVENTS",
+                } as ToggleAction) // Dispatch action to toggle the state
+            }
           />
         </SettingSection>
 
@@ -100,16 +117,22 @@ export const SettingsModal = () => {
           <SettingTitle>
             <Label>Star Mentor 🎯</Label>
             <SettingDescription>
-              Are you a star mentor? Turn on admin functionality
+              Are you a star mentor? Turn on the admin functionality
             </SettingDescription>
           </SettingTitle>
           <Switch
-            //checked={}
-            //onCheckedChange={}
+            checked={toggleState.starMentor} // Use the toggle state
+            onCheckedChange={
+              () =>
+                toggleDispatch({
+                  type: "TOGGLE_STAR_MENTOR",
+                } as ToggleAction) // Dispatch action to toggle the state
+            }
             disabled
             aria-readonly
           />
         </SettingSection>
+
       </DialogContent>
     </Dialog>
   );

--- a/components/providers/SettingsReducerProvider.tsx
+++ b/components/providers/SettingsReducerProvider.tsx
@@ -1,0 +1,100 @@
+import {
+  createContext,
+  Dispatch,
+  SetStateAction,
+  useContext,
+  useReducer,
+  useEffect,
+} from "react";
+import toast from "react-hot-toast";
+
+export type ToggleAction =
+  | { type: "TOGGLE_GENERAL_NOTIFICATIONS" }
+  | { type: "TOGGLE_HIDE_CORRECT_ANSWER" }
+  | { type: "TOGGLE_LOG_EVENTS" }
+  | { type: "TOGGLE_STAR_MENTOR" };
+
+interface CombinedSettingsState {
+  generalNotifications: boolean;
+  hideCorrectAnswer: boolean;
+  logEvents: boolean;
+  starMentor: boolean;
+}
+
+const initialState: CombinedSettingsState = {
+  generalNotifications: true,
+  hideCorrectAnswer: false,
+  logEvents: false,
+  starMentor: false,
+};
+
+const toggleReducer = (
+  state: CombinedSettingsState,
+  action: ToggleAction
+): CombinedSettingsState => {
+  switch (action.type) {
+    case "TOGGLE_GENERAL_NOTIFICATIONS":
+      return { ...state, generalNotifications: !state.generalNotifications };
+    case "TOGGLE_HIDE_CORRECT_ANSWER":
+      return { ...state, hideCorrectAnswer: !state.hideCorrectAnswer };
+    case "TOGGLE_LOG_EVENTS":
+      return { ...state, logEvents: !state.logEvents };
+    case "TOGGLE_STAR_MENTOR":
+      return { ...state, starMentor: !state.starMentor };
+    default:
+      return state; //- if action doesnt match - reducer will return current state (wont break app)
+  }
+};
+
+export const SettingsReducerContext = createContext<{
+  state: CombinedSettingsState;
+  dispatch: Dispatch<ToggleAction>;
+}>({
+  state: initialState,
+  dispatch: () => null,
+});
+
+// 👇 Custom hook to simplify working w/ the SettingsReducerContext
+export function useSettingsReducerContext() {
+  const context = useContext(SettingsReducerContext);
+  if (!context) {
+    throw new Error(
+      "❌Settings Reducer;  useSettingsReducerContext must be used within SettingsReducerContext"
+    );
+  }
+  return context;
+}
+
+type SettingsReducerProviderProps = {
+  children: React.ReactNode;
+};
+
+export const SettingsReducerProvider: React.FC<SettingsReducerProviderProps> = ({
+  children,
+}) => {
+  // 👇 Load settings from local storage on app load
+  const savedSettings = localStorage.getItem("ztmready-setings");
+  const initialSettings = savedSettings
+    ? JSON.parse(savedSettings)
+    : initialState;
+
+  const [state, dispatch] = useReducer(toggleReducer, initialSettings);
+
+  // 👇 Update local storage whenever settings change
+  useEffect(() => {
+    try {
+      localStorage.setItem("ztmready-setings", JSON.stringify(state));
+    } catch (error) {
+      //- error handling for cases where the local storage is full or not available.
+      // 🎯 to-do-list:  Better handle the error here (req: logger)
+      toast.error("Failed to save state to local storage:");
+      console.log("Failed to save state to local storage:", error);
+    }
+  }, [state]);
+
+  return (
+    <SettingsReducerContext.Provider value={{ state, dispatch }}>
+      {children}
+    </SettingsReducerContext.Provider>
+  );
+};

--- a/lib/useCustomToast.ts
+++ b/lib/useCustomToast.ts
@@ -1,0 +1,14 @@
+import { useSettingsReducerContext } from '@/components/providers/SettingsReducerProvider';
+import { toast, ToastOptions } from 'react-hot-toast';
+
+export function useCustomToast() {
+  const { state } = useSettingsReducerContext();
+
+  const customToast = (message: string, options: ToastOptions = {}) => {
+    if (state.generalNotifications) {
+      toast(message, options);
+    }
+  };
+
+  return customToast;
+}


### PR DESCRIPTION
Centralizes context for managing various user settings in the application. It leverages a reducer for state transitions and provides persistence by storing the user’s preferences in local storage. 

Additionally, to manage the General Notifications - it further  introduces a custom toast notification hook that checks the `generalNotifications` setting before showing a toast notification.

## Project Ticket Reference 
[**Implement Quick Settings Functionality**](https://github.com/users/DevonGifford/projects/2/views/1?pane=issue&itemId=45706682)

## Closing following tickets:

- #6

- #7

- #8
